### PR TITLE
Ignore *_spec.lua files

### DIFF
--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -260,7 +260,7 @@ module MrMurano
         end
       end.flatten.compact.reject do |path|
         # TODO: These globs should be in $cfg.
-        path.fnmatch('*_test.lua') or path.basename.fnmatch('.*')
+        path.fnmatch('*_test.lua') or path.fnmatch('*_spec.lua') or path.basename.fnmatch('.*')
       end.select do |path|
         # TODO: These globs should be in $cfg.
         path.extname == '.lua'


### PR DESCRIPTION
[Busted's](https://olivinelabs.com/busted/) default pattern is `_spec.lua` for test files, so ignoring these by default in MrMurano would reduce the configuration needed to ignore test scripts.