### PR TITLE
overwrite instead of append for .env file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -105,7 +105,7 @@ cat >> .mrmurano.prod <<EOF
 id=CCCCCCCC
 EOF
 
-cat >> .env <<EOF
+cat > .env <<EOF
 MR_CONFIGFILE=.mrmurano.dev
 EOF
 ```


### PR DESCRIPTION
cat >> .env seems to work, but is there any reason to append rather than overwrite when setting the .env file?