### PR TITLE
Don't auth with client_id when deleting devices

### DIFF
--- a/lib/MrMurano/Product-1P-Device.rb
+++ b/lib/MrMurano/Product-1P-Device.rb
@@ -86,7 +86,7 @@ module MrMurano
     # +sn+:: Identifier for a device
     def remove(sn)
       # First drop it from the 1P database
-      do_rpc({:id=>1, :procedure=>:drop, :arguments=>[sn_rid(sn)]})
+      do_rpc({:id=>1, :procedure=>:drop, :arguments=>[sn_rid(sn)]}, nil)
       # Then remove it from the provisioning databases
       psn = ProductSerialNumber.new
       psn.remove_sn(sn)

--- a/lib/MrMurano/Product.rb
+++ b/lib/MrMurano/Product.rb
@@ -64,7 +64,7 @@ module MrMurano
       maxid = ((calls.max_by{|c| c[:id] or 0 }[:id]) or 0)
       calls.map!{|c| c[:id] = (maxid += 1) unless c.has_key?(:id); c}
       post('', {
-        :auth=>{:client_id=>cid},
+        :auth=>(cid ? {:client_id=>cid} : {}),
         :calls=>calls
       })
     end


### PR DESCRIPTION
"mr product device delete <sn>" will make the following RPC call:
curl -s \
     -H 'Authorization: token <TOKEN>' \
     -H 'User-Agent: MrMurano/1.12.3' \
     -H 'Content-Type: application/json' \
     -X POST
     'https://bizapi.hosted.exosite.io/api:1/product/<PID>/proxy/onep:v1/rpc/process'
     -d '{"auth":{"client_id":"<MODEL_RID>"},"calls":[{"id":1,"procedure":"drop","arguments":["RID"]}]}'

This results in the following, which is ignored:
[{"id":1,"status":"restricted"}]

Turns out "drop" doesn't like '"auth":{"client_id":"<MODEL_RID>"}', if
no auth is provided (or if auth is assigned to {}), the delete succeeds
with [{"id":1,"status":"ok"}]. The code, however, unconditionally passes
this auth, though.

Fix this by passing nil as the second argument to do_rpc. This overrides
the default value (model_rid). Then, tweak do_mrpc to pass an empty
"auth" when cid is nil.

(Issue: MRMUR-43)